### PR TITLE
Modify GENRAY examples to use CompX binaries in /atom/cori/binaries/g…

### DIFF
--- a/GENRAY_stand_alone_examples/GENRAY_DIII-D_LH_example/GENRAY_LH.config
+++ b/GENRAY_stand_alone_examples/GENRAY_DIII-D_LH_example/GENRAY_LH.config
@@ -21,8 +21,8 @@ USER = Batchelor       		# Optional, if missing the unix username is used
 # ======================================================================
 
 IPS_ROOT = $IPS_PATH
-COMPONENTS_ROOT = $IPS_DIR/ips-wrappers
-
+#COMPONENTS_ROOT = $IPS_DIR/ips-wrappers
+COMPONENTS_ROOT = $IPS_WRAPPER_PATH
 # ======================================================================
 # SIMULATION INFO SECTION
 # ======================================================================
@@ -157,7 +157,7 @@ ALL_PLASMA_STATE_FILES = $CURRENT_STATE $CURRENT_EQDSK $CURRENT_CQL
     ADJ_READ = disabled
     PS_ADD_NML = disabled
     BIN_PATH = $COMPONENTS_ROOT/ips-genray/
-    GENRAY_BIN = /global/cfs/cdirs/m77/CompX/GENRAY/xgenray_mpi_intel.cori
+    GENRAY_BIN = $GENRAY_EXEC 
     INPUT_DIR = $SIM_INPUT_DIR/genray_LH_input/
         INPUT_SUFFIX =
         INPUT_FILES = genray.in_LH

--- a/GENRAY_stand_alone_examples/GENRAY_DIII-D_LH_example/run_slurm
+++ b/GENRAY_stand_alone_examples/GENRAY_DIII-D_LH_example/run_slurm
@@ -7,7 +7,12 @@
 #SBATCH --constraint=haswell
 
 cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
-source env.GENRAY_DIII_D_LH_example 
+source $IPS_WRAPPER_PATH/env.ips.cori   # N.B. This is the Cori installation
+# Switch to use the local wrappers (e.g for development)
+source $LOCAL_WRAPPER_PATH/use_local_wrappers
+#
+source $IPS_WRAPPER_PATH/env.COMPX_codes
 ips.py --config=GENRAY_LH.config --platform=conf.ips.cori --log=log.framework 2>>log.stdErr 1>>log.stdOut
 egrep -i 'error' log.* > log.errors
 ./setPermissions.sh
+

--- a/GENRAY_stand_alone_examples/GENRAY_ITER_EC_example/GENRAY_SA.config
+++ b/GENRAY_stand_alone_examples/GENRAY_ITER_EC_example/GENRAY_SA.config
@@ -21,7 +21,7 @@ USER = Batchelor       		# Optional, if missing the unix username is used
 # ======================================================================
 
 IPS_ROOT = $IPS_PATH
-COMPONENTS_ROOT = $IPS_DIR/ips-wrappers
+COMPONENTS_ROOT = $IPS_WRAPPER_PATH
 
 # ======================================================================
 # SIMULATION INFO SECTION
@@ -138,7 +138,8 @@ ALL_PLASMA_STATE_FILES = $CURRENT_STATE $CURRENT_EQDSK
     ADJ_READ = disabled
     PS_ADD_NML = disabled
     BIN_PATH = $COMPONENTS_ROOT/ips-genray/
-    GENRAY_BIN = /global/cfs/cdirs/m77/CompX/GENRAY/xgenray_mpi_intel.cori
+    #GENRAY_BIN = /global/cfs/cdirs/m77/CompX/GENRAY/xgenray_mpi_intel.cori
+    GENRAY_BIN = $GENRAY_EXEC
     INPUT_DIR = $SIM_INPUT_DIR/genray_EC_input/
         INPUT_SUFFIX =
         INPUT_FILES = genray.in_EC

--- a/GENRAY_stand_alone_examples/GENRAY_ITER_EC_example/run_slurm
+++ b/GENRAY_stand_alone_examples/GENRAY_ITER_EC_example/run_slurm
@@ -7,7 +7,12 @@
 #SBATCH --constraint=haswell
 
 cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
-source env.GENRAY_ITER_EC_example
+source $IPS_WRAPPER_PATH/env.ips.cori   # N.B. This is the Cori installation
+# Switch to use the local wrappers (e.g for development)
+source $LOCAL_WRAPPER_PATH/use_local_wrappers
+#
+source $IPS_WRAPPER_PATH/env.COMPX_codes
 ips.py --config=GENRAY_SA.config --platform=conf.ips.cori --log=log.framework 2>>log.stdErr 1>>log.stdOut
 egrep -i 'error' log.* > log.errors
 ./setPermissions.sh
+

--- a/GENRAY_stand_alone_examples/GENRAY_basic_example/Cori_run_EC
+++ b/GENRAY_stand_alone_examples/GENRAY_basic_example/Cori_run_EC
@@ -7,8 +7,13 @@
 #SBATCH --constraint=haswell
 
 cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
-source env.GENRAY_basic_example
-export PYTHONPATH=$PWD/_exec:PYTHONPATH
+source $IPS_WRAPPER_PATH/env.ips.cori   # N.B. This is the Cori installation
+# Switch to use the local wrappers (e.g for development)
+source $LOCAL_WRAPPER_PATH/use_local_wrappers
+source $LOCAL_WRAPPER_PATH/use_local_examples
+#
+source $IPS_WRAPPER_PATH/env.COMPX_codes
 ips.py --config=GENRAY_basic_example_EC.config --platform=conf.ips.cori --log=log.framework 2>>log.stdErr 1>>log.stdOut
 egrep -i 'error' log.* > log.errors
 ./setPermissions.sh
+

--- a/GENRAY_stand_alone_examples/GENRAY_basic_example/GENRAY_basic_example_EC.config
+++ b/GENRAY_stand_alone_examples/GENRAY_basic_example/GENRAY_basic_example_EC.config
@@ -19,8 +19,8 @@ USER_W3_BASEURL =
 # ======================================================================
 
 IPS_ROOT = $IPS_PATH
-IPS_COMPONENTS_ROOT = $PWD/_exec
-
+#IPS_COMPONENTS_ROOT = $PWD/_exec
+IPS_COMPONENTS_ROOT = $IPS_WRAPPER_PATH
 # ======================================================================
 # SIMULATION INFO SECTION
 # ======================================================================
@@ -95,7 +95,7 @@ PLASMA_STATE_FILES =
 
  [basic_driver]
 # Machine dependent config info
-    BIN_PATH = $IPS_COMPONENTS_ROOT
+    BIN_PATH = $IPS_COMPONENTS_ROOT/generic-drivers
     SCRIPT = $BIN_PATH/basic_driver.py
 # Static config info
     CLASS = driver
@@ -109,10 +109,10 @@ PLASMA_STATE_FILES =
 
 [rf_genray]
 # Machine dependent config info
-    BIN_PATH = $IPS_COMPONENTS_ROOT
+    BIN_PATH = $IPS_COMPONENTS_ROOT/ips-genray
     SCRIPT = $BIN_PATH/GENRAY_basic_component.py
-    # full path to Bob's latest
-    EXECUTABLE = /global/cfs/cdirs/m77/CompX/GENRAY/xgenray_mpi_intel.cori 
+#    SCRIPT = $PWD/_exec/GENRAY_basic_component.py
+    EXECUTABLE = $GENRAY_EXEC 
 # Static config info
     CLASS = rf_genray
     SUB_CLASS =


### PR DESCRIPTION
Merging changes to GENRAY examples to be able to use /global/common/software/atom/cori/ installation and use the CompX binaries in the /global/common/software/atom/cori/binaries/ collection